### PR TITLE
Changes to the data model to reconcile with caac-map

### DIFF
--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -1,6 +1,12 @@
 class Opportunity < ActiveRecord::Base
   has_many :opportunity_instances
   belongs_to :organizer
+  has_one :after_this, class_name: "Opportunity", foreign_key: "after_this_id"
+  has_one :before_this, class_name: "Opportunity", foreign_key: "before_this_id"
+  belongs_to :resource_sub_type
+  has_one :resource_type, through: :resource_sub_type
+
+  validates :resource_sub_type, presence: true
 
   def active_model_serializer
     OpportunitySerializer

--- a/app/models/opportunity_instance.rb
+++ b/app/models/opportunity_instance.rb
@@ -3,11 +3,21 @@ class OpportunityInstance < ActiveRecord::Base
   has_one :organizer, through: :opportunity
   belongs_to :location
   belongs_to :topic
+  belongs_to :resource_sub_type
+  has_one :resource_type, through: :resource_sub_type
 
   validates :difficulty, numericality: { greater_than: 0, less_than: 4 }, allow_blank: true
   validates :duration, numericality: true, allow_blank: true
 
   def active_model_serializer
     OpportunityInstanceSerializer
+  end
+
+  def resource_type
+    self[:resource_type] ? self[:resource_type] : self.opportunity.resource_type
+  end
+
+  def resource_sub_type
+    self[:resource_sub_type] ? self[:resource_sub_type] : self.opportunity.resource_sub_type
   end
 end

--- a/app/models/resource_sub_type.rb
+++ b/app/models/resource_sub_type.rb
@@ -1,0 +1,9 @@
+class ResourceSubType < ActiveRecord::Base
+  has_many :opportunities
+  has_many :opportunity_instances
+  belongs_to :resource_type
+
+  def active_model_serializer
+    ResourceSubTypeSerializer
+  end
+end

--- a/app/models/resource_type.rb
+++ b/app/models/resource_type.rb
@@ -1,0 +1,7 @@
+class ResourceType < ActiveRecord::Base
+  has_many :resource_sub_types
+
+  def active_model_serializer
+    ResourceTypeSerializer
+  end
+end

--- a/app/serializers/opportunity_instance_serializer.rb
+++ b/app/serializers/opportunity_instance_serializer.rb
@@ -1,6 +1,6 @@
 class OpportunityInstanceSerializer < ActiveModel::Serializer
   root :result
-  attributes :context, :type, :uid, :id, :name, :description, :img
+  attributes :context, :uid, :id, :name, :description, :img
   has_one :organizer
   attributes :min_age, :max_age, :venue_name, :online_opportunity, :ongoing,
     :price, :registration_deadline, :registration_url, :created, :changed,
@@ -9,10 +9,6 @@ class OpportunityInstanceSerializer < ActiveModel::Serializer
 
   def uid
     object.id
-  end
-
-  def type
-    'EducationEvent'
   end
 
   def context

--- a/app/serializers/opportunity_serializer.rb
+++ b/app/serializers/opportunity_serializer.rb
@@ -1,18 +1,15 @@
 class OpportunitySerializer < ActiveModel::Serializer
   root :result
-  attributes :context, :type, :uid, :id, :name, :description
+  attributes :context, :uid, :id, :name, :description
   has_one :organizer
-  attributes :min_age, :max_age
+  attributes :badge_class_id, :min_age, :max_age
   attributes :registration_deadline, :registration_url, :created,
     :changed, :ends, :starts
+  attributes :after_this, :before_this, :resource_type, :resource_sub_type
   #has_one :topic
 
   def uid
     object.id
-  end
-
-  def type
-    'EducationEvent'
   end
 
   def context
@@ -37,5 +34,21 @@ class OpportunitySerializer < ActiveModel::Serializer
 
   def starts
     object.starts_at
+  end
+
+  def after_this
+    object.after_this.id unless object.after_this.nil?
+  end
+
+  def before_this
+    object.before_this.id unless object.before_this.nil?
+  end
+
+  def resource_type
+    object.resource_type.name
+  end
+
+  def resource_sub_type
+    object.resource_sub_type.name
   end
 end

--- a/app/serializers/resource_sub_type_serializer.rb
+++ b/app/serializers/resource_sub_type_serializer.rb
@@ -1,0 +1,3 @@
+class ResourceSubTypeSerializer < ActiveModel::Serializer
+  attributes :name
+end

--- a/app/serializers/resource_type_serializer.rb
+++ b/app/serializers/resource_type_serializer.rb
@@ -1,0 +1,3 @@
+class ResourceTypeSerializer < ActiveModel::Serializer
+  attributes :name
+end

--- a/db/migrate/20151002145004_add_after_and_before_this_to_opportunities.rb
+++ b/db/migrate/20151002145004_add_after_and_before_this_to_opportunities.rb
@@ -1,0 +1,6 @@
+class AddAfterAndBeforeThisToOpportunities < ActiveRecord::Migration
+  def change
+    add_reference :opportunities, :after_this, index: true
+    add_reference :opportunities, :before_this, index: true
+  end
+end

--- a/db/migrate/20151002162525_add_badge_class_id_to_opportunities.rb
+++ b/db/migrate/20151002162525_add_badge_class_id_to_opportunities.rb
@@ -1,0 +1,5 @@
+class AddBadgeClassIdToOpportunities < ActiveRecord::Migration
+  def change
+    add_column :opportunities, :badge_class_id, :string
+  end
+end

--- a/db/migrate/20151002195425_create_resource_types.rb
+++ b/db/migrate/20151002195425_create_resource_types.rb
@@ -1,0 +1,7 @@
+class CreateResourceTypes < ActiveRecord::Migration
+  def change
+    create_table :resource_types do |t|
+        t.string :name
+    end
+  end
+end

--- a/db/migrate/20151002203739_create_resource_sub_types.rb
+++ b/db/migrate/20151002203739_create_resource_sub_types.rb
@@ -1,0 +1,10 @@
+class CreateResourceSubTypes < ActiveRecord::Migration
+  def change
+    create_table :resource_sub_types do |t|
+        t.string :name
+        t.belongs_to :resource_type, index: true
+    end
+    add_reference :opportunities, :resource_sub_type, index: true
+    add_reference :opportunity_instances, :resource_sub_type, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150809030551) do
+ActiveRecord::Schema.define(version: 20151002203739) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,9 +58,16 @@ ActiveRecord::Schema.define(version: 20150809030551) do
     t.datetime "updated_at",            null: false
     t.integer  "organizer_id"
     t.integer  "topic_id"
+    t.integer  "after_this_id"
+    t.integer  "before_this_id"
+    t.string   "badge_class_id"
+    t.integer  "resource_sub_type_id"
   end
 
+  add_index "opportunities", ["after_this_id"], name: "index_opportunities_on_after_this_id", using: :btree
+  add_index "opportunities", ["before_this_id"], name: "index_opportunities_on_before_this_id", using: :btree
   add_index "opportunities", ["organizer_id"], name: "index_opportunities_on_organizer_id", using: :btree
+  add_index "opportunities", ["resource_sub_type_id"], name: "index_opportunities_on_resource_sub_type_id", using: :btree
   add_index "opportunities", ["topic_id"], name: "index_opportunities_on_topic_id", using: :btree
 
   create_table "opportunity_instances", force: :cascade do |t|
@@ -102,12 +109,14 @@ ActiveRecord::Schema.define(version: 20150809030551) do
     t.string   "neighborhood"
     t.integer  "duration"
     t.integer  "difficulty"
+    t.integer  "resource_sub_type_id"
   end
 
   add_index "opportunity_instances", ["difficulty"], name: "index_opportunity_instances_on_difficulty", using: :btree
   add_index "opportunity_instances", ["duration"], name: "index_opportunity_instances_on_duration", using: :btree
   add_index "opportunity_instances", ["location_id"], name: "index_opportunity_instances_on_location_id", using: :btree
   add_index "opportunity_instances", ["opportunity_id"], name: "index_opportunity_instances_on_opportunity_id", using: :btree
+  add_index "opportunity_instances", ["resource_sub_type_id"], name: "index_opportunity_instances_on_resource_sub_type_id", using: :btree
   add_index "opportunity_instances", ["topic_id"], name: "index_opportunity_instances_on_topic_id", using: :btree
 
   create_table "organizers", force: :cascade do |t|
@@ -121,6 +130,17 @@ ActiveRecord::Schema.define(version: 20150809030551) do
   end
 
   add_index "organizers", ["topic_id"], name: "index_organizers_on_topic_id", using: :btree
+
+  create_table "resource_sub_types", force: :cascade do |t|
+    t.string  "name"
+    t.integer "resource_type_id"
+  end
+
+  add_index "resource_sub_types", ["resource_type_id"], name: "index_resource_sub_types_on_resource_type_id", using: :btree
+
+  create_table "resource_types", force: :cascade do |t|
+    t.string "name"
+  end
 
   create_table "topics", force: :cascade do |t|
     t.string   "name"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,20 +7,23 @@ codeandsupply = Organizer.create(name: 'Code & Supply', description: 'Pittsburgh
 saxifrage = Organizer.create(name: 'Saxifrage School', description: 'The Saxifrage School is a higher education laboratory working to lower costs, re-think the campus, and reconcile theory with practice.', url: 'http://www.saxifrageschool.org/', logo_url: 'http://www.saxifrageschool.org/img/saxifrage_logo.png')
 Organizer.create(name: 'Assemble', description: 'Maker gallery', url: '', logo_url: '')
 
-starterseries = Opportunity.create(name: '#StarterSeries', description: 'Learn to code', organizer: codeandsupply)
-profdev = Opportunity.create(name: 'Professional Development', description: 'Get yourself a better job', organizer: codeandsupply)
+film = ResourceSubType.create(name: 'Film', resource_type: ResourceType.create(name: 'Digital'))
+workshop = ResourceSubType.create(name: 'Workshop', resource_type: ResourceType.create(name: 'Local'))
 
-Opportunity.create(name: 'Carpentry courses', organizer: saxifrage)
+starterseries = Opportunity.create(name: '#StarterSeries', description: 'Learn to code', organizer: codeandsupply, resource_sub_type: film)
+profdev = Opportunity.create(name: 'Professional Development', description: 'Get yourself a better job', organizer: codeandsupply, resource_sub_type: workshop)
 
-OpportunityInstance.create(name: 'Software Design Patterns', opportunity: starterseries, starts_at: Time.now+1.hours, ends_at: Time.now + 2.hours, location: cloakroom, topic: software, neighborhood: neighborhood, logo_url: random_img)
-OpportunityInstance.create(name: 'Tools of the Trade', opportunity: starterseries, starts_at: Time.now+1.hours, ends_at: Time.now + 2.hours, location: cloakroom, topic: software, neighborhood: neighborhood, logo_url: random_img)
+Opportunity.create(name: 'Carpentry courses', organizer: saxifrage, resource_sub_type: workshop)
+
+OpportunityInstance.create(name: 'Software Design Patterns', opportunity: starterseries, starts_at: Time.now+1.hours, ends_at: Time.now + 2.hours, location: cloakroom, topic: software, neighborhood: neighborhood, logo_url: random_img, resource_sub_type: film)
+OpportunityInstance.create(name: 'Tools of the Trade', opportunity: starterseries, starts_at: Time.now+1.hours, ends_at: Time.now + 2.hours, location: cloakroom, topic: software, neighborhood: neighborhood, logo_url: random_img, resource_sub_type: workshop)
 OpportunityInstance.create(name: 'Software Testing', opportunity: starterseries, starts_at: Time.now+1.hours, ends_at: Time.now + 2.hours, location: cloakroom, topic: software, neighborhood: neighborhood, logo_url: random_img)
 OpportunityInstance.create(name: 'Programming Principles', opportunity: starterseries, starts_at: Time.now+1.hours, ends_at: Time.now + 2.hours, location: cloakroom, topic: software, neighborhood: neighborhood, logo_url: random_img)
 
 junky_organizer = Organizer.create(name: 'Spam organizer')
 junky_opportunities = []
 10.times do |n|
-  junky_opportunities << Opportunity.create(name: "Opportunity #{n}", description: "This is a class. It'll teach you about #{n}", organizer: codeandsupply)
+  junky_opportunities << Opportunity.create(name: "Opportunity #{n}", description: "This is a class. It'll teach you about #{n}", organizer: codeandsupply, resource_sub_type: workshop)
 end
 
 junky_opportunities.each do |opp|
@@ -35,7 +38,8 @@ junky_opportunities.each do |opp|
     price: Random.rand(100),
     min_age: 4,
     max_age: Random.rand(99),
-    logo_url: random_img
+    logo_url: random_img,
+    resource_sub_type: film
   ).save!
 
   opp.opportunity_instances.build(
@@ -49,6 +53,7 @@ junky_opportunities.each do |opp|
     price: Random.rand(100),
     min_age: 4,
     max_age: Random.rand(99),
-    logo_url: random_img
+    logo_url: random_img,
+    resource_sub_type: workshop
   ).save!
 end


### PR DESCRIPTION
- Added `after_this` and `before_this` attributes to `Opportunity` which are references to other opportunities.
- Added `badge_class_id` to `Opportunity`, which should reference a badge class id url ala the [open badges spec](https://openbadgespec.org/#BadgeClass).
- Added `resource_type` and `resource_sub_type` models and subsequent attributes to `Opportunity` and `OpportunityInstance` which default to opportunity's if the instance doesn't have one.
- Removed hardcoded `type` on `Opportunity` and `OpportunityInstance`
- Updated seed data

@MatthewVita @timothyfcook yinz want to take a look at this? should reconcile differences we found with caac-map in #163.

@whit537 turns out nothing really seems to need to change in caac-map itself, I updated the google spreadsheet, maybe regenerate `output/topics.json`. I tried but failed, having trouble with python 3.5 on my vagrant.
