### PR TITLE
Add comment regarding resource type fall back

### DIFF
--- a/app/models/opportunity_instance.rb
+++ b/app/models/opportunity_instance.rb
@@ -14,10 +14,12 @@ class OpportunityInstance < ActiveRecord::Base
   end
 
   def resource_type
+    # Fall back to the Opportunity's resource type if the instance doesn't have one
     self[:resource_type] ? self[:resource_type] : self.opportunity.resource_type
   end
 
   def resource_sub_type
+    # Fall back to the Opportunity's resource sub type if the instance doesn't have one
     self[:resource_sub_type] ? self[:resource_sub_type] : self.opportunity.resource_sub_type
   end
 end


### PR DESCRIPTION
@MatthewVita I added some comments to clarify the fallback behavior of `OpportunityInstance.resource_type` and `resource_sub_type` as requested in #250 
