### PR TITLE
Opportunity and Opportunity Instance within an Organizer context

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'kaminari'
 gem 'api-pagination'
 gem 'devise'
 gem 'textacular', '~> 3.0'
+gem 'pundit'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,8 @@ GEM
       pry (>= 0.9.10)
     puma (2.11.1)
       rack (>= 1.1, < 2.0)
+    pundit (1.0.1)
+      activesupport (>= 3.0.0)
     rack (1.6.0)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -193,6 +195,7 @@ DEPENDENCIES
   pg
   pry-rails
   puma
+  pundit
   rails (= 4.2.1)
   rails_12factor
   rails_serve_static_assets

--- a/app/assets/javascripts/opportunities.coffee
+++ b/app/assets/javascripts/opportunities.coffee
@@ -1,3 +1,27 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
+
+toggle_address = () ->
+  if $("#opportunity_is_online").prop("checked")
+    $("#opportunity_online_container").show()
+    $("#opportunity_offline_container").hide()
+  else
+    $("#opportunity_online_container").hide()
+    $("#opportunity_offline_container").show()
+
+toggle_hide_reason = () ->
+  if $("#opportunity_hide").prop("checked")
+    $("#opportunity_hide_reason_container").show()
+  else
+    $("#opportunity_hide_reason_container").hide()
+
+$(document).on "page:change", ->
+  $("#opportunity_hide").click (e) ->
+    toggle_hide_reason()
+
+  $("#opportunity_is_online").click (e) ->
+    toggle_address()
+
+  toggle_address()
+  toggle_hide_reason()

--- a/app/assets/javascripts/opportunity_instances.coffee
+++ b/app/assets/javascripts/opportunity_instances.coffee
@@ -1,3 +1,27 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
+
+toggle_address = () ->
+  if $("#opportunity_instance_is_online").prop("checked")
+    $("#opportunity_instance_online_container").show()
+    $("#opportunity_instance_offline_container").hide()
+  else
+    $("#opportunity_instance_online_container").hide()
+    $("#opportunity_instance_offline_container").show()
+
+toggle_hide_reason = () ->
+  if $("#opportunity_instance_hide").prop("checked")
+    $("#opportunity_instance_hide_reason_container").show()
+  else
+    $("#opportunity_instance_hide_reason_container").hide()
+
+$(document).on "page:change", ->
+  $("#opportunity_instance_hide").click (e) ->
+    toggle_hide_reason()
+
+  $("#opportunity_instance_is_online").click (e) ->
+    toggle_address()
+
+  toggle_address()
+  toggle_hide_reason()

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,8 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception 
+  include Pundit
+  protect_from_forgery with: :exception
 
   def index
     if signed_in?

--- a/app/controllers/opportunities_controller.rb
+++ b/app/controllers/opportunities_controller.rb
@@ -1,11 +1,12 @@
 class OpportunitiesController < ApplicationController
   before_action :set_opportunity, only: [:show, :edit, :update, :destroy]
+  before_action :set_organizers, only: [:edit, :new]
   before_action :authenticate_user!, except: [:index, :show]
 
   # GET /opportunities
   # GET /opportunities.json
   def index
-    @opportunities = Opportunity.all
+    @opportunities = policy_scope(Opportunity)
     respond_to do |format|
       format.html { render 'dashboard/opportunities' }
       format.json { render json: @opportunities }
@@ -15,7 +16,10 @@ class OpportunitiesController < ApplicationController
   # GET /opportunities/1
   # GET /opportunities/1.json
   def show
-    render json: @opportunity
+    respond_to do |format|
+      format.html
+      format.json { render json: @opportunity }
+    end
   end
 
   # GET /opportunities/new
@@ -25,13 +29,14 @@ class OpportunitiesController < ApplicationController
 
   # GET /opportunities/1/edit
   def edit
+    authorize @opportunity
   end
 
   # POST /opportunities
   # POST /opportunities.json
   def create
     @opportunity = Opportunity.new(opportunity_params)
-
+    authorize @opportunity
     respond_to do |format|
       if @opportunity.save
         format.html { redirect_to @opportunity, notice: 'Opportunity was successfully created.' }
@@ -46,6 +51,7 @@ class OpportunitiesController < ApplicationController
   # PATCH/PUT /opportunities/1
   # PATCH/PUT /opportunities/1.json
   def update
+    authorize @opportunity
     respond_to do |format|
       if @opportunity.update(opportunity_params)
         format.html { redirect_to @opportunity, notice: 'Opportunity was successfully updated.' }
@@ -60,6 +66,7 @@ class OpportunitiesController < ApplicationController
   # DELETE /opportunities/1
   # DELETE /opportunities/1.json
   def destroy
+    authorize @opportunity
     @opportunity.destroy
     respond_to do |format|
       format.html { redirect_to opportunities_url, notice: 'Opportunity was successfully destroyed.' }
@@ -73,8 +80,18 @@ class OpportunitiesController < ApplicationController
       @opportunity = Opportunity.find(params[:id])
     end
 
+    def set_organizers
+      @organizers = current_user.organizers
+    end
+
     # Never trust parameters from the scary internet, only allow the white list through.
     def opportunity_params
-      params.require(:opportunity).permit(:name, :address, :description, :registration_url, :location_name, :registration_deadline, :program_type, :logo_url, :starts_at, :ends_at, :online_address, :zipcode, :city, :state, :is_online, :hide_reason, :hide, :contact_name, :contact_email, :contact_phone, :registration_url, :price_level, :min_age, :max_age, :extra_data)
+      permitted_params = [:name, :address, :description, :registration_url, :location_name,
+                          :registration_deadline, :program_type, :logo_url, :starts_at,
+                          :ends_at, :online_address, :zipcode, :city, :state, :is_online,
+                          :hide_reason, :hide, :contact_name, :contact_email, :contact_phone,
+                          :registration_url, :price_level, :min_age, :max_age, :extra_data,
+                          :organizer_id, :resource_sub_type_id]
+      params.require(:opportunity).permit(permitted_params)
     end
 end

--- a/app/controllers/opportunity_instances_controller.rb
+++ b/app/controllers/opportunity_instances_controller.rb
@@ -1,8 +1,9 @@
 class OpportunityInstancesController < ApplicationController
   before_action :set_opportunity_instance, only: [:show, :edit, :update, :destroy]
+  before_action :set_opportunities, only: [:edit, :new]
 
   def index
-    @opportunity_instances = OpportunityInstance.all
+    @opportunity_instances = policy_scope(OpportunityInstance)
     @paginator = OpenStruct.new(opportunity_instances: @opportunity_instances, per_page: 15)
 
     respond_to do |format|
@@ -12,6 +13,7 @@ class OpportunityInstancesController < ApplicationController
   end
 
   def show
+    authorize @opportunity_instance
     respond_to do |format|
       format.html { render :show }
       format.json { render json: @opportunity_instance, root: :result, serializer: OpportunityInstanceSerializer }
@@ -63,12 +65,14 @@ class OpportunityInstancesController < ApplicationController
 
   # GET /opportunity_instances/1/edit
   def edit
+    authorize @opportunity_instance
   end
 
   # POST /opportunity_instances
   # POST /opportunity_instances.json
   def create
     @opportunity_instance = OpportunityInstance.new(opportunity_instance_params)
+    authorize @opportunity_instance
 
     respond_to do |format|
       if @opportunity_instance.save
@@ -84,6 +88,8 @@ class OpportunityInstancesController < ApplicationController
   # PATCH/PUT /opportunity_instances/1
   # PATCH/PUT /opportunity_instances/1.json
   def update
+    authorize @opportunity_instance
+
     respond_to do |format|
       if @opportunity_instance.update(opportunity_instance_params)
         format.html { redirect_to @opportunity_instance, notice: 'Opportunity instance was successfully updated.' }
@@ -98,6 +104,7 @@ class OpportunityInstancesController < ApplicationController
   # DELETE /opportunity_instances/1
   # DELETE /opportunity_instances/1.json
   def destroy
+    authorize @opportunity_instance
     @opportunity_instance.destroy
     respond_to do |format|
       format.html { redirect_to opportunity_instances_url, notice: 'Opportunity instance was successfully destroyed.' }
@@ -111,8 +118,18 @@ class OpportunityInstancesController < ApplicationController
       @opportunity_instance = OpportunityInstance.find(params[:id])
     end
 
+    def set_opportunities
+      @opportunities = policy_scope(Opportunity)
+    end
+
     # Never trust parameters from the scary internet, only allow the white list through.
     def opportunity_instance_params
-      params.require(:opportunity_instance).permit(:name, :address, :description, :registration_url, :location_name, :registration_deadline, :program_type, :logo_url, :starts_at, :ends_at, :online_address, :zipcode, :city, :state, :is_online, :hide_reason, :hide, :contact_name, :contact_email, :contact_phone, :registration_url, :price_level, :min_age, :max_age, :extra_data, :duration, :difficulty)
+      permitted_params = [:name, :address, :description, :registration_url, :location_name,
+                          :registration_deadline, :program_type, :logo_url, :starts_at,
+                          :ends_at, :online_address, :zipcode, :city, :state, :is_online,
+                          :hide_reason, :hide, :contact_name, :contact_email, :contact_phone,
+                          :registration_url, :price_level, :min_age, :max_age, :extra_data,
+                          :duration, :difficulty, :resource_sub_type_id, :opportunity_id]
+      params.require(:opportunity_instance).permit(permitted_params)
     end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    scope.where(:id => record.id).exists?
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  def scope
+    Pundit.policy_scope!(user, record.class)
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/opportunity_instance_policy.rb
+++ b/app/policies/opportunity_instance_policy.rb
@@ -1,0 +1,28 @@
+class OpportunityInstancePolicy < ApplicationPolicy
+  def create?
+    user.organizers.include? record.organizer
+  end
+
+  def destroy?
+    user.organizers.include? record.organizer
+  end
+
+  def edit?
+    user.organizers.include? record.organizer
+  end
+
+  def new?
+    user.organizers.include? record.organizer
+  end
+
+  def update?
+    user.organizers.include? record.organizer
+  end
+
+  class Scope < Scope
+    def resolve
+      OpportunityInstance.joins(:opportunity)
+                         .where(opportunities: { organizer_id: user.organizers })
+    end
+  end
+end

--- a/app/policies/opportunity_policy.rb
+++ b/app/policies/opportunity_policy.rb
@@ -1,0 +1,27 @@
+class OpportunityPolicy < ApplicationPolicy
+  def create?
+    user.organizers.include? record.organizer
+  end
+
+  def destroy?
+    user.organizers.include? record.organizer
+  end
+
+  def edit?
+    user.organizers.include? record.organizer
+  end
+
+  def new?
+    user.organizers.include? record.organizer
+  end
+
+  def update?
+    user.organizers.include? record.organizer
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.where(organizer: user.organizers)
+    end
+  end
+end

--- a/app/views/dashboard/opportunities.html.erb
+++ b/app/views/dashboard/opportunities.html.erb
@@ -18,7 +18,7 @@
       <% @opportunities.each do |opportunity| %>
         <tr>
           <td><%= opportunity.name %></td>
-          <td><%= link_to "<button>edit</button>".html_safe, edit_opportunity_path(opportunity) %>
+          <td><%= link_to "<button>show</button>".html_safe, opportunity %> <%= link_to "<button>edit</button>".html_safe, edit_opportunity_path(opportunity) %>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/opportunities/_form.html.erb
+++ b/app/views/opportunities/_form.html.erb
@@ -94,10 +94,6 @@
     <%= f.text_field :contact_phone %>
   </div>
   <div class="field">
-    <%= f.label :registration_url %><br>
-    <%= f.text_field :registration_url %>
-  </div>
-  <div class="field">
     <%= f.label :price_level %><br>
     <%= f.number_field :price_level %>
   </div>

--- a/app/views/opportunities/_form.html.erb
+++ b/app/views/opportunities/_form.html.erb
@@ -16,10 +16,6 @@
     <%= f.text_field :name %>
   </div>
   <div class="field">
-    <%= f.label :address %><br>
-    <%= f.text_area :address %>
-  </div>
-  <div class="field">
     <%= f.label :description %><br>
     <%= f.text_area :description %>
   </div>
@@ -33,11 +29,11 @@
   </div>
   <div class="field">
     <%= f.label :registration_deadline %><br>
-    <%= f.datetime_select :registration_deadline %>
+    <%= f.datetime_local_field :registration_deadline %>
   </div>
   <div class="field">
-    <%= f.label :program_type %><br>
-    <%= f.text_field :program_type %>
+    <%= f.label :resource_sub_type %><br>
+    <%= f.collection_select :resource_sub_type_id, ResourceSubType.all, :id, :name %>
   </div>
   <div class="field">
     <%= f.label :logo_url %><br>
@@ -45,39 +41,45 @@
   </div>
   <div class="field">
     <%= f.label :starts_at %><br>
-    <%= f.datetime_select :starts_at %>
+    <%= f.datetime_local_field :starts_at %>
   </div>
   <div class="field">
     <%= f.label :ends_at %><br>
-    <%= f.datetime_select :ends_at %>
-  </div>
-  <div class="field">
-    <%= f.label :online_address %><br>
-    <%= f.text_field :online_address %>
-  </div>
-  <div class="field">
-    <%= f.label :zipcode %><br>
-    <%= f.text_field :zipcode %>
-  </div>
-  <div class="field">
-    <%= f.label :city %><br>
-    <%= f.text_field :city %>
-  </div>
-  <div class="field">
-    <%= f.label :state %><br>
-    <%= f.text_field :state %>
+    <%= f.datetime_local_field :ends_at %>
   </div>
   <div class="field">
     <%= f.label :is_online %><br>
     <%= f.check_box :is_online %>
   </div>
-  <div class="field">
-    <%= f.label :hide_reason %><br>
-    <%= f.text_field :hide_reason %>
+  <div class="field" id="opportunity_online_container">
+    <%= f.label :online_address %><br>
+    <%= f.text_field :online_address %>
+  </div>
+  <div id="opportunity_offline_container">
+    <div class="field">
+      <%= f.label :address %><br>
+      <%= f.text_area :address %>
+    </div>
+    <div class="field">
+      <%= f.label :city %><br>
+      <%= f.text_field :city %>
+    </div>
+    <div class="field">
+      <%= f.label :state %><br>
+      <%= f.text_field :state %>
+    </div>
+    <div class="field">
+      <%= f.label :zipcode %><br>
+      <%= f.text_field :zipcode %>
+    </div>
   </div>
   <div class="field">
     <%= f.label :hide %><br>
     <%= f.check_box :hide %>
+  </div>
+  <div class="field" id="opportunity_hide_reason_container">
+    <%= f.label :hide_reason %><br>
+    <%= f.text_field :hide_reason %>
   </div>
   <div class="field">
     <%= f.label :contact_name %><br>
@@ -113,7 +115,7 @@
   </div>
   <div class="field">
     <%= f.label :organizer %><br>
-    <%= f.select :organizer_id, options_from_collection_for_select(Organizer.all, :id, :name) %>
+    <%= f.collection_select :organizer_id, @organizers, :id, :name %>
   </div>
   <div class="actions">
     <%= f.submit %>

--- a/app/views/opportunities/show.html.erb
+++ b/app/views/opportunities/show.html.erb
@@ -113,11 +113,6 @@
 </p>
 
 <p>
-  <strong>Registration url:</strong>
-  <%= @opportunity.registration_url %>
-</p>
-
-<p>
   <strong>Price level:</strong>
   <%= @opportunity.price_level %>
 </p>

--- a/app/views/opportunities/show.html.erb
+++ b/app/views/opportunities/show.html.erb
@@ -8,13 +8,13 @@
 </p>
 
 <p>
-  <strong>Address:</strong>
-  <%= @opportunity.address %>
+  <strong>Description:</strong>
+  <%= @opportunity.description %>
 </p>
 
 <p>
-  <strong>Description:</strong>
-  <%= @opportunity.description %>
+  <strong>Organizer:</strong>
+  <%= @opportunity.organizer.name %>
 </p>
 
 <p>
@@ -33,8 +33,13 @@
 </p>
 
 <p>
-  <strong>Program type:</strong>
-  <%= @opportunity.program_type %>
+  <strong>Resource type:</strong>
+  <%= @opportunity.resource_type.name %>
+</p>
+
+<p>
+  <strong>Resource sub-type:</strong>
+  <%= @opportunity.resource_sub_type.name %>
 </p>
 
 <p>
@@ -58,8 +63,8 @@
 </p>
 
 <p>
-  <strong>Zipcode:</strong>
-  <%= @opportunity.zipcode %>
+  <strong>Address:</strong>
+  <%= @opportunity.address %>
 </p>
 
 <p>
@@ -70,6 +75,11 @@
 <p>
   <strong>State:</strong>
   <%= @opportunity.state %>
+</p>
+
+<p>
+  <strong>Zipcode:</strong>
+  <%= @opportunity.zipcode %>
 </p>
 
 <p>

--- a/app/views/opportunity_instances/_form.html.erb
+++ b/app/views/opportunity_instances/_form.html.erb
@@ -16,10 +16,6 @@
     <%= f.text_field :name %>
   </div>
   <div class="field">
-    <%= f.label :address %><br>
-    <%= f.text_area :address %>
-  </div>
-  <div class="field">
     <%= f.label :description %><br>
     <%= f.text_area :description %>
   </div>
@@ -41,11 +37,11 @@
   </div>
   <div class="field">
     <%= f.label :registration_deadline %><br>
-    <%= f.datetime_select :registration_deadline %>
+    <%= f.datetime_local_field :registration_deadline %>
   </div>
   <div class="field">
-    <%= f.label :program_type %><br>
-    <%= f.text_field :program_type %>
+    <%= f.label :resource_sub_type %><br>
+    <%= f.collection_select :resource_sub_type_id, ResourceSubType.all, :id, :name, include_blank: true %>
   </div>
   <div class="field">
     <%= f.label :logo_url %><br>
@@ -53,39 +49,45 @@
   </div>
   <div class="field">
     <%= f.label :starts_at %><br>
-    <%= f.datetime_select :starts_at %>
+    <%= f.datetime_local_field :starts_at %>
   </div>
   <div class="field">
     <%= f.label :ends_at %><br>
-    <%= f.datetime_select :ends_at %>
-  </div>
-  <div class="field">
-    <%= f.label :online_address %><br>
-    <%= f.text_field :online_address %>
-  </div>
-  <div class="field">
-    <%= f.label :zipcode %><br>
-    <%= f.text_field :zipcode %>
-  </div>
-  <div class="field">
-    <%= f.label :city %><br>
-    <%= f.text_field :city %>
-  </div>
-  <div class="field">
-    <%= f.label :state %><br>
-    <%= f.text_field :state %>
+    <%= f.datetime_local_field :ends_at %>
   </div>
   <div class="field">
     <%= f.label :is_online %><br>
     <%= f.check_box :is_online %>
   </div>
-  <div class="field">
-    <%= f.label :hide_reason %><br>
-    <%= f.text_field :hide_reason %>
+  <div class="field" id="opportunity_instance_online_container">
+    <%= f.label :online_address %><br>
+    <%= f.text_field :online_address %>
+  </div>
+  <div id="opportunity_instance_offline_container">
+    <div class="field">
+      <%= f.label :address %><br>
+      <%= f.text_area :address %>
+    </div>
+    <div class="field">
+      <%= f.label :city %><br>
+      <%= f.text_field :city %>
+    </div>
+    <div class="field">
+      <%= f.label :zipcode %><br>
+      <%= f.text_field :zipcode %>
+    </div>
+    <div class="field">
+      <%= f.label :state %><br>
+      <%= f.text_field :state %>
+    </div>
   </div>
   <div class="field">
     <%= f.label :hide %><br>
     <%= f.check_box :hide %>
+  </div>
+  <div class="field" id="opportunity_instance_hide_reason_container">
+    <%= f.label :hide_reason %><br>
+    <%= f.text_field :hide_reason %>
   </div>
   <div class="field">
     <%= f.label :contact_name %><br>
@@ -121,7 +123,7 @@
   </div>
   <div class="field">
     <%= f.label :opportunity %><br>
-    <%= f.select :opportunity_id, options_from_collection_for_select(Opportunity.all, :id, :name) %>
+    <%= f.collection_select :opportunity_id, @opportunities, :id, :name %>
   </div>
   <div class="actions">
     <%= f.submit %>

--- a/app/views/opportunity_instances/_form.html.erb
+++ b/app/views/opportunity_instances/_form.html.erb
@@ -102,10 +102,6 @@
     <%= f.text_field :contact_phone %>
   </div>
   <div class="field">
-    <%= f.label :registration_url %><br>
-    <%= f.text_field :registration_url %>
-  </div>
-  <div class="field">
     <%= f.label :price_level %><br>
     <%= f.number_field :price_level %>
   </div>

--- a/app/views/opportunity_instances/show.html.erb
+++ b/app/views/opportunity_instances/show.html.erb
@@ -6,13 +6,18 @@
 </p>
 
 <p>
-  <strong>Address:</strong>
-  <%= @opportunity_instance.address %>
+  <strong>Description:</strong>
+  <%= @opportunity_instance.description %>
 </p>
 
 <p>
-  <strong>Description:</strong>
-  <%= @opportunity_instance.description %>
+  <strong>Opportunity:</strong>
+  <%= @opportunity_instance.opportunity.name %>
+</p>
+
+<p>
+  <strong>Organizer:</strong>
+  <%= @opportunity_instance.organizer.name %>
 </p>
 
 <p>
@@ -31,8 +36,13 @@
 </p>
 
 <p>
-  <strong>Program type:</strong>
-  <%= @opportunity_instance.program_type %>
+  <strong>Resource type:</strong>
+  <%= @opportunity_instance.resource_type.name %>
+</p>
+
+<p>
+  <strong>Resource sub-type:</strong>
+  <%= @opportunity_instance.resource_sub_type.name %>
 </p>
 
 <p>
@@ -56,8 +66,8 @@
 </p>
 
 <p>
-  <strong>Zipcode:</strong>
-  <%= @opportunity_instance.zipcode %>
+  <strong>Address:</strong>
+  <%= @opportunity_instance.address %>
 </p>
 
 <p>
@@ -68,6 +78,11 @@
 <p>
   <strong>State:</strong>
   <%= @opportunity_instance.state %>
+</p>
+
+<p>
+  <strong>Zipcode:</strong>
+  <%= @opportunity_instance.zipcode %>
 </p>
 
 <p>

--- a/app/views/opportunity_instances/show.html.erb
+++ b/app/views/opportunity_instances/show.html.erb
@@ -116,11 +116,6 @@
 </p>
 
 <p>
-  <strong>Registration url:</strong>
-  <%= @opportunity_instance.registration_url %>
-</p>
-
-<p>
   <strong>Price level:</strong>
   <%= @opportunity_instance.price_level %>
 </p>


### PR DESCRIPTION
- List Opportunities and Opportunity Instances
  - Scoped to those within the users organizer(s) using the [pundit gem](https://github.com/elabs/pundit)
- Edit Opportunity and Opportunity Instance
  - Users are authorized to edit based on their organizer(s), again using pundit
  - Dynamically displays online address and hide reason fields based on checking of `is_online` and `hide` parameters
  - Fixed a bug where certain fields were not being permitted on update for Opportunity and Opportunity Instances
- Show Opportunity and Opportunity Instances
  - General clean up to reflect the current list of relevant fields
